### PR TITLE
change specific JDK version to inheritedJdk

### DIFF
--- a/fs-challenge-squad-school-admin.iml
+++ b/fs-challenge-squad-school-admin.iml
@@ -5,7 +5,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
     </content>
-    <orderEntry type="jdk" jdkName="17" jdkType="JavaSDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>


### PR DESCRIPTION
Ao invés de especificar o JDK versão 17 no arquivo .iml, mudei para "inheritedJdk" pois acredito que vai ter maior compatibilidade e causar menos problemas.